### PR TITLE
Doc update and removed error returns

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -44,7 +44,7 @@ type Client interface {
 	GetVisit() (*VisitResponse, error)
 	GetStatus() (*StatusResponse, error)
 	DeleteVisit() (bool, error)
-	GetCookies() ([]*http.Cookie, error)
+	GetCookies() []*http.Cookie
 }
 
 // Config is the configuration of the usageanalytics client
@@ -60,8 +60,8 @@ type Config struct {
 }
 
 // NewClient return a capable Coveo Usage Analytics service client. It currently
-// uses V14 of the API.
-func NewClient(c Config) (Client, error) {
+// uses V15 of the API.
+func NewClient(c Config) Client {
 	if len(c.Endpoint) == 0 {
 		c.Endpoint = EndpointProduction
 	}
@@ -70,8 +70,7 @@ func NewClient(c Config) (Client, error) {
 		endpoint:   c.Endpoint,
 		httpClient: http.DefaultClient,
 		useragent:  c.UserAgent,
-		ip:         c.IP,
-	}, nil
+		ip:         c.IP}
 }
 
 type client struct {
@@ -84,7 +83,7 @@ type client struct {
 }
 
 // NewSearchEvent creates a new SearchEvent which can then be altered
-func NewSearchEvent() (*SearchEvent, error) {
+func NewSearchEvent() *SearchEvent {
 	return &SearchEvent{
 		ActionEvent: &ActionEvent{
 			Language:     "en",
@@ -96,11 +95,11 @@ func NewSearchEvent() (*SearchEvent, error) {
 		QueryText:      "",
 		ActionCause:    "interfaceLoad",
 		Contextual:     false,
-	}, nil
+	}
 }
 
 // NewClickEvent creates a new ClickEvent which can then be altered
-func NewClickEvent() (*ClickEvent, error) {
+func NewClickEvent() *ClickEvent {
 	return &ClickEvent{
 		ActionEvent: &ActionEvent{
 			Language:     "en",
@@ -115,11 +114,11 @@ func NewClickEvent() (*ClickEvent, error) {
 		SourceName:       "",
 		DocumentPosition: 0,
 		ActionCause:      "documentOpen",
-	}, nil
+	}
 }
 
 // NewCustomEvent creates a new SearchEvent which can then be altered
-func NewCustomEvent() (*CustomEvent, error) {
+func NewCustomEvent() *CustomEvent {
 	return &CustomEvent{
 		ActionEvent: &ActionEvent{
 			Language:     "en",
@@ -130,7 +129,7 @@ func NewCustomEvent() (*CustomEvent, error) {
 		EventType:          "",
 		EventValue:         "",
 		LastSearchQueryUID: "",
-	}, nil
+	}
 }
 
 // NewViewEvent creates a ViewEvent which can then be changed
@@ -163,8 +162,8 @@ type CustomEventResponse struct{}
 // VisitResponse is the response to a Visit call
 type VisitResponse struct{}
 
-func (c *client) GetCookies() ([]*http.Cookie, error) {
-	return c.cookies, nil
+func (c *client) GetCookies() []*http.Cookie {
+	return c.cookies
 }
 
 func (c *client) SendSearchEvent(event *SearchEvent) error {

--- a/analytics/events.go
+++ b/analytics/events.go
@@ -1,5 +1,7 @@
 package analytics
 
+// ActionEvent Basic incomplete analytics event type, contains most of the information
+// sent from a search ui to the analytics
 type ActionEvent struct {
 	Language            string                 `json:"language"`
 	Device              string                 `json:"device"`
@@ -16,6 +18,8 @@ type ActionEvent struct {
 	OriginLevel3        string                 `json:"originLevel3,omitempty"`
 }
 
+// SearchEvent Is a structure reprensenting a search event sent to the analytics
+// It incorporate an ActionEvent and adds more fields.
 type SearchEvent struct {
 	*ActionEvent
 	SearchQueryUID  string       `json:"searchQueryUid"`
@@ -30,11 +34,15 @@ type SearchEvent struct {
 	Results         []ResultHash `json:"results,omitempty"`
 }
 
+// ResultHash Is a type used by the analytics to describe a result that was
+// returned by a query that is usually sent with a search event.
 type ResultHash struct {
 	DocumentURI     string `json:"documentUri"`
 	DocumentURIHash string `json:"documentUriHash"`
 }
 
+// ClickEvent Is a structure reprensenting a click event sent to the analytics
+// It incorporate an ActionEvent and adds more fields.
 type ClickEvent struct {
 	*ActionEvent
 	DocumentURI      string `json:"documentUri"`
@@ -50,6 +58,8 @@ type ClickEvent struct {
 	RankingModifier  string `json:"rankingModifier,omitempty"`
 }
 
+// CustomEvent Is a structure reprensenting a custom event sent to the analytics
+// It incorporate an ActionEvent and adds more fields.
 type CustomEvent struct {
 	*ActionEvent
 	EventType          string `json:"eventType"`
@@ -57,6 +67,8 @@ type CustomEvent struct {
 	LastSearchQueryUID string `json:"lastSearchQueryUid,omitempty"`
 }
 
+// ViewEvent Is a structure reprensenting a view event sent to the analytics
+// It incorporate an ActionEvent and adds more fields.
 type ViewEvent struct {
 	*ActionEvent
 	PageURI      string `json:"location"`

--- a/search/client_test.go
+++ b/search/client_test.go
@@ -1,8 +1,9 @@
 package search_test
 
 import (
-	"github.com/coveo/go-coveo/search"
 	"testing"
+
+	"github.com/coveo/go-coveo/search"
 )
 
 func TestClient(t *testing.T) {

--- a/search/query.go
+++ b/search/query.go
@@ -1,5 +1,6 @@
 package search
 
+// Query Struct reprensenting a query sent to the index.
 type Query struct {
 	Q               string            `json:"q,omitempty"`
 	AQ              string            `json:"aq,omitempty"`
@@ -11,6 +12,8 @@ type Query struct {
 	Tab             string            `json:"tab,omitempty"`
 }
 
+// GroupByRequest Struct representing a GroupByRequest send to the index. It is
+// used to send data to the facets of a search page.
 type GroupByRequest struct {
 	Field                 string `json:"field"`
 	MaximumNumberOfValues int    `json:"maximumNumberOfValues,omitempty"`

--- a/search/response.go
+++ b/search/response.go
@@ -1,5 +1,7 @@
 package search
 
+// Response A collection of results from the Coveo index following a query.
+// It contains the results that were returned from the query and some metadata.
 type Response struct {
 	TotalCount         int             `json:"totalCount"`
 	TotalCountFiltered int             `json:"totalCountFiltered"`
@@ -12,6 +14,7 @@ type Response struct {
 	Results            []Result        `json:"results,omitempty"`
 }
 
+// Result A single result returned from a query to the Coveo index.
 type Result struct {
 	Title          string                 `json:"title"`
 	URI            string                 `json:"uri"`
@@ -19,10 +22,11 @@ type Result struct {
 	FirstSentences string                 `json:"firstSentences"`
 	Score          int                    `json:"score"`
 	PercentScore   float32                `json:"percentScore"`
-	ClickUri       string                 `json:"clickUri"`
+	ClickURI       string                 `json:"clickUri"`
 	Raw            map[string]interface{} `json:"raw"`
 }
 
+// GroupByResult The result of a group by request to the index.
 type GroupByResult struct {
 	Field  string `json:"field"`
 	Values []struct {


### PR DESCRIPTION
Commented all exported structs and methods for the linter.

Removed unnecessary error returns in methods that couldn't fail
