### PR TITLE
#21 Validate that UA calls return status 200.

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -3,6 +3,8 @@ package analytics
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -237,6 +239,13 @@ func (c *client) sendEventRequest(path string, event interface{}) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(body[:]))
+	}
 
 	if c.cookies == nil {
 		cookies := resp.Cookies()


### PR DESCRIPTION
Validate that UA calls return status 200.

Added an error when the return status is not 200 and it will return the body as string.