### PR TITLE
Added links to the documentation of the APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ go-coveo
 [![Build Status](https://travis-ci.org/coveo/go-coveo.svg)](https://travis-ci.org/coveo/go-coveo)
 [![Go Report](https://goreportcard.com/badge/github.com/coveo/go-coveo)](https://goreportcard.com/report/github.com/coveo/go-coveo)
 
-go-coveo is a Go client library for accessing the [Coveo API]()
+go-coveo is a Go client library for accessing the [Coveo Search API](https://docs.coveo.com/en/13/cloud-v2-api-reference/search-api) and the [Coveo Usage Analytics API](https://docs.coveo.com/en/18/cloud-v2-api-reference/usage-analytics-write-api)
 
 
+# Analytics client documentation
+
+https://godoc.org/github.com/coveo/go-coveo/analytics
+
+# Search client documentation
+
+https://godoc.org/github.com/coveo/go-coveo/search


### PR DESCRIPTION
Added a link to the CloudV2 SearchAPI documentation page.
Added a link to the Usage Analytics Write API documentation page.

Added links to the godoc.org documentation pages.